### PR TITLE
Pieces Can Move (Logically, this time!)

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -85,17 +85,18 @@ function setEvents () {
     console.log("current piece", currentPiece);
     let selectedSpace = pieces.getCoordinates($(e.currentTarget));
 
-
     if (currentPiece.canMove) {
       currentPiece.validMoves.forEach( function (coords) {
         if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
           currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+          currentPiece.validMoves = []
         }
       })
     }
     currentPiece.validJumps.forEach( function (coords) {
       if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
         currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+        currentPiece.validJumps = []
       }
     })
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -43,20 +43,34 @@ function setEvents () {
     let jump1 = pieces.getPieceFromArray($(`[x=${x+2}][y=${y+(2*number)}]`));
     let jump2 = pieces.getPieceFromArray($(`[x=${x-2}][y=${y+(2*number)}]`));
 
-    if (move1 === null || move2 === null){
+    if (move1 === null){
       console.log("can move")
       currentPiece.canMove = true;
+      currentPiece.validMoves.push({x: x + 1, y: y+number})
+      console.log(currentPiece)
+    }
+    if (move2 === null){
+      console.log("can move")
+      currentPiece.canMove = true;
+      currentPiece.validMoves.push({x: x - 1, y: y+number})
+      console.log(currentPiece)
     }
     if (move1){
       if (move1.color === opponent && !jump1){
         console.log("can jump")
         currentPiece.canJump = true;
+        currentPiece.canMove = false;
+        currentPiece.validJumps.push({x: x + 2, y: y+(2 * number)})
+        console.log(currentPiece)
       }
     }
     if (move2){
       if (move2.color === opponent && !jump2){
         console.log("can jump")
         currentPiece.canJump = true;
+        currentPiece.canMove = false;
+        currentPiece.validJumps.push({x: x - 2, y: y+(2 * number)})
+        console.log(currentPiece)
       }
     }
     _movePhase = currentPiece.canMove || currentPiece.canJump
@@ -75,6 +89,8 @@ function setEvents () {
 
 };
 
+//Future fixes: Make .canMove = false if .canJump = true
+
 module.exports = setEvents;
 
 
@@ -87,6 +103,8 @@ var Piece = function(){
   this.canBeJumped = false;
   this.color = null;
   this.node = null;
+  this.validMoves = [];
+  this.validJumps = [];
 }
 Piece.prototype.jump = function(){
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -77,6 +77,7 @@ function setEvents () {
   };
 
 //Okay for some reason currentPiece.validMoves grows out of control sometimes.
+//Also sometimes, the array is populated with double copies of movement coordinates
 //Not totally sure why, honestly
 //Each piece's moves keep getting added to the arrays
 
@@ -84,7 +85,15 @@ function setEvents () {
     console.log("current piece", currentPiece);
     let selectedSpace = pieces.getCoordinates($(e.currentTarget));
 
-    currentPiece.validMoves.forEach( function (coords) {
+
+    if (currentPiece.canMove) {
+      currentPiece.validMoves.forEach( function (coords) {
+        if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
+          currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+        }
+      })
+    }
+    currentPiece.validJumps.forEach( function (coords) {
       if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
         currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
       }
@@ -93,7 +102,6 @@ function setEvents () {
     _movePhase = false;
     pieces.populatePieces();
   }
-
 };
 
 //Future fixes: Make .canMove = false if .canJump = true

--- a/dist/app.js
+++ b/dist/app.js
@@ -90,12 +90,14 @@ function setEvents () {
         if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
           currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
           currentPiece.validMoves = []
+          currentPiece.validJumps = []
         }
       })
     }
     currentPiece.validJumps.forEach( function (coords) {
       if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
         currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+        currentPiece.validMoves = []
         currentPiece.validJumps = []
       }
     })

--- a/dist/app.js
+++ b/dist/app.js
@@ -76,13 +76,20 @@ function setEvents () {
     _movePhase = currentPiece.canMove || currentPiece.canJump
   };
 
+//Okay for some reason currentPiece.validMoves grows out of control sometimes.
+//Not totally sure why, honestly
+//Each piece's moves keep getting added to the arrays
+
   function makeMove(currentPiece, e){
     console.log("current piece", currentPiece);
     let selectedSpace = pieces.getCoordinates($(e.currentTarget));
-    console.log("New Location x", selectedSpace.x);
-    console.log("New Location y", selectedSpace.y);
-    currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
-    console.log(currentPiece);
+
+    currentPiece.validMoves.forEach( function (coords) {
+      if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
+        currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+      }
+    })
+
     _movePhase = false;
     pieces.populatePieces();
   }

--- a/js/events.js
+++ b/js/events.js
@@ -42,20 +42,34 @@ function setEvents () {
     let jump1 = pieces.getPieceFromArray($(`[x=${x+2}][y=${y+(2*number)}]`));
     let jump2 = pieces.getPieceFromArray($(`[x=${x-2}][y=${y+(2*number)}]`));
 
-    if (move1 === null || move2 === null){
+    if (move1 === null){
       console.log("can move")
       currentPiece.canMove = true;
+      currentPiece.validMoves.push({x: x + 1, y: y+number})
+      console.log(currentPiece)
+    }
+    if (move2 === null){
+      console.log("can move")
+      currentPiece.canMove = true;
+      currentPiece.validMoves.push({x: x - 1, y: y+number})
+      console.log(currentPiece)
     }
     if (move1){
       if (move1.color === opponent && !jump1){
         console.log("can jump")
         currentPiece.canJump = true;
+        currentPiece.canMove = false;
+        currentPiece.validJumps.push({x: x + 2, y: y+(2 * number)})
+        console.log(currentPiece)
       }
     }
     if (move2){
       if (move2.color === opponent && !jump2){
         console.log("can jump")
         currentPiece.canJump = true;
+        currentPiece.canMove = false;
+        currentPiece.validJumps.push({x: x - 2, y: y+(2 * number)})
+        console.log(currentPiece)
       }
     }
     _movePhase = currentPiece.canMove || currentPiece.canJump
@@ -73,6 +87,8 @@ function setEvents () {
   }
 
 };
+
+//Future fixes: Make .canMove = false if .canJump = true
 
 module.exports = setEvents;
 

--- a/js/events.js
+++ b/js/events.js
@@ -84,17 +84,18 @@ function setEvents () {
     console.log("current piece", currentPiece);
     let selectedSpace = pieces.getCoordinates($(e.currentTarget));
 
-
     if (currentPiece.canMove) {
       currentPiece.validMoves.forEach( function (coords) {
         if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
           currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+          currentPiece.validMoves = []
         }
       })
     }
     currentPiece.validJumps.forEach( function (coords) {
       if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
         currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+        currentPiece.validJumps = []
       }
     })
 

--- a/js/events.js
+++ b/js/events.js
@@ -76,6 +76,7 @@ function setEvents () {
   };
 
 //Okay for some reason currentPiece.validMoves grows out of control sometimes.
+//Also sometimes, the array is populated with double copies of movement coordinates
 //Not totally sure why, honestly
 //Each piece's moves keep getting added to the arrays
 
@@ -83,7 +84,15 @@ function setEvents () {
     console.log("current piece", currentPiece);
     let selectedSpace = pieces.getCoordinates($(e.currentTarget));
 
-    currentPiece.validMoves.forEach( function (coords) {
+
+    if (currentPiece.canMove) {
+      currentPiece.validMoves.forEach( function (coords) {
+        if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
+          currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+        }
+      })
+    }
+    currentPiece.validJumps.forEach( function (coords) {
       if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
         currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
       }
@@ -92,7 +101,6 @@ function setEvents () {
     _movePhase = false;
     pieces.populatePieces();
   }
-
 };
 
 //Future fixes: Make .canMove = false if .canJump = true

--- a/js/events.js
+++ b/js/events.js
@@ -75,13 +75,20 @@ function setEvents () {
     _movePhase = currentPiece.canMove || currentPiece.canJump
   };
 
+//Okay for some reason currentPiece.validMoves grows out of control sometimes.
+//Not totally sure why, honestly
+//Each piece's moves keep getting added to the arrays
+
   function makeMove(currentPiece, e){
     console.log("current piece", currentPiece);
     let selectedSpace = pieces.getCoordinates($(e.currentTarget));
-    console.log("New Location x", selectedSpace.x);
-    console.log("New Location y", selectedSpace.y);
-    currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
-    console.log(currentPiece);
+
+    currentPiece.validMoves.forEach( function (coords) {
+      if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
+        currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+      }
+    })
+
     _movePhase = false;
     pieces.populatePieces();
   }

--- a/js/events.js
+++ b/js/events.js
@@ -89,12 +89,14 @@ function setEvents () {
         if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
           currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
           currentPiece.validMoves = []
+          currentPiece.validJumps = []
         }
       })
     }
     currentPiece.validJumps.forEach( function (coords) {
       if (parseInt(selectedSpace.x) === coords.x && parseInt(selectedSpace.y) === coords.y) {
         currentPiece.changeCoords(parseInt(selectedSpace.x), parseInt(selectedSpace.y));
+        currentPiece.validMoves = []
         currentPiece.validJumps = []
       }
     })

--- a/js/pieces.js
+++ b/js/pieces.js
@@ -6,6 +6,8 @@ var Piece = function(){
   this.canBeJumped = false;
   this.color = null;
   this.node = null;
+  this.validMoves = [];
+  this.validJumps = [];
 }
 Piece.prototype.jump = function(){
 


### PR DESCRIPTION
Pieces can now only move if the selectedSpace coordinates match up with the coordinates within their validMoves or validJumps arrays. Afterward, those arrays are emptied out to prevent a weird movement bug when a selected space was PREVIOUSLY in the validMoves array-- making it a valid move much later than expected. (Please just ask me to explain this in class so I can make sure I understand it)
